### PR TITLE
KAFKA-4320: Update log compaction docs for default cleaner

### DIFF
--- a/docs/design.html
+++ b/docs/design.html
@@ -653,6 +653,15 @@
     To enable log cleaning on a particular topic, add the log-specific property
     <pre class="language-text"><code>log.cleanup.policy=compact</code></pre>
 
+ <p>
+Kafka’s <strong>log cleaner</strong> (compaction) is <strong>enabled by default</strong> 
+(since version 0.9.0.1). Topics are compacted when their topic-level 
+<code>cleanup.policy</code> includes <code>compact</code>. The broker configuration 
+<code>log.cleaner.enable</code> controls whether the cleaner process runs, and should 
+normally remain enabled if you use compacted topics.
+</p>
+
+
     The <code>log.cleanup.policy</code> property is a broker configuration setting defined
     in the broker's <code>server.properties</code> file; it affects all of the topics
     in the cluster that do not have a configuration override in place as documented


### PR DESCRIPTION
This PR updates the website docs to correct outdated wording about log compaction defaults. The log cleaner has been enabled by default since Kafka 0.9.0.1, so the docs should not state that compaction is disabled by default. The text now explains that compaction happens for topics configured with `cleanup.policy=compact`, and that the cleaner process is on by default.

References:
- 0.9.0 docs note about `log.cleaner.enable` default true: https://kafka.apache.org/090/documentation/
- Prior discussion/PRs around KAFKA-4320: https://issues.apache.org/jira/browse/KAFKA-4320


